### PR TITLE
use finished macro - breaking change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drujensen/crystal:0.21.0
+FROM drujensen/crystal:0.21.1
 
 WORKDIR /app/user
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,9 @@ require "kemalyst-model/adapter/mysql"
 
 class Post < Kemalyst::Model
   adapter mysql
-
-  sql_mapping({
-    name: String,
-    body: String
-  })
-
+  field name : String
+  field body : Text
+  timestamps
 end
 ```
 
@@ -69,13 +66,9 @@ require "kemalyst-model/adapter/sqlite"
 
 class Comment < Kemalyst::Model
   adapter sqlite
-
-  # table name is set to post_comments and timestamps are disabled.
-  sql_mapping({
-    name: String,
-    body: String
-  }, "post_comments", false)
-
+  table_name post_comments
+  field name : String
+  field body : Text
 end
 ```
 ### Fields

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -3,12 +3,11 @@ require "../src/adapter/mysql"
 
 class Post < Kemalyst::Model
   adapter mysql
-  sql_mapping({
-    name:  String,
-    body:  String,
-    total: Int32,
-    slug:  String,
-  })
+  field name :  String
+  field body :  String
+  field total : Int32
+  field slug :  String
+  timestamps
 end
 
 Post.exec("DROP TABLE IF EXISTS posts;");

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -3,11 +3,10 @@ require "../src/adapter/pg"
 
 class User < Kemalyst::Model
   adapter pg
-  sql_mapping({
-    name:  String,
-    pass:  String,
-    total: Int32,
-  })
+  field name :  String
+  field pass :  String
+  field total : Int32
+  timestamps
 end
 
 User.exec("DROP TABLE IF EXISTS users;")

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -3,10 +3,9 @@ require "../src/adapter/sqlite"
 
 class Comment < Kemalyst::Model
   adapter sqlite
-  sql_mapping({
-    name: String,
-    body: String,
-  }, comments, false)
+  table_name comments
+  field name : String
+  field body : String
 end
 
 Comment.exec("DROP TABLE IF EXISTS comments;")

--- a/spec/kemalyst-model_spec.cr
+++ b/spec/kemalyst-model_spec.cr
@@ -3,10 +3,8 @@ require "../src/adapter/pg"
 
 class Todo < Kemalyst::Model
   adapter pg
-
-  sql_mapping({
-    name: String,
-  })
+  field name : String
+  timestamps
 
   def initialize(@name)
   end


### PR DESCRIPTION
@elorest @TechMagister I am introducing a breaking change to the models.  There is a new feature added to crystal that provides a `finished` macro to allow you to only process them at the end.

This allows us to have a model that looks like this:

```crystal
require "../src/adapter/mysql"

class Post < Kemalyst::Model
  adapter mysql
  field name : String
  field body : Text
  field total : Int32
  field draft : Bool
  timestamps
end
```

thoughts?